### PR TITLE
Increase the daily scrap value based on how many quotas completed

### DIFF
--- a/DynamicDeadline/DynamicDeadline.cs
+++ b/DynamicDeadline/DynamicDeadline.cs
@@ -25,9 +25,9 @@ namespace DynamicDeadlineMod
 
         static internal ConfigEntry<float> MinScrapValuePerDay;
 
-        static internal ConfigEntry<bool> legacyCal;
+        static internal ConfigEntry<bool> incrementalCal;
 
-        static internal ConfigEntry<float> legacyDailyValue;
+        static internal ConfigEntry<float> incrementalDailyValue;
 
         static internal ConfigEntry<bool> useMinMax;
 
@@ -56,9 +56,9 @@ namespace DynamicDeadlineMod
 
             setMaximumDays = Config.Bind("Customizable Values", "Maximum Deadline", float.MaxValue, "If use Custom Deadline Range is enabled, this is the maximum deadline you will have.");
 
-            legacyCal = Config.Bind("Customizeable Values - Legacy", "Legacy Calculations", false, "Set to true if you want to use the deadline calculation from 1.1.0 prior.");
+            incrementalCal = Config.Bind("Customizeable Values - Incremental", "Incremental Calculations", false, "Toggle this option to activate deadline-based calculation for incrementally raising the MinScrapValuePerDay each time you meet a quota, ensuring a slower increase in the amount of days. This will Disable the default bevahiour of increasing this based on average of your daily scrap.");
 
-            legacyDailyValue = Config.Bind("Customizeable Values - Legacy", "Daily Scrap Value", 200f, "Set this number to the value of scrap you can reasonably achieve in a single day.");
+            incrementalDailyValue = Config.Bind("Customizable Values", "Incremental Daily Value", 30f, "If Use incremental minimum daily ScrapValue, this is the amount it will increase every time a quota is complete.");
 
             harmony.PatchAll(typeof(DynamicDeadlineMod));
             harmony.PatchAll(typeof(ProfitQuotaPatch));

--- a/DynamicDeadline/Patches/ProfitQuotaPatch.cs
+++ b/DynamicDeadline/Patches/ProfitQuotaPatch.cs
@@ -95,7 +95,7 @@ namespace DynamicDeadlineMod.Patches
                 DynamicDeadlineMod.Instance.mls.LogInfo($"Could not load totalOfAverage variable as it does not exist! Creating now!");
             }
 
-            if (isHost && DynamicDeadlineMod.legacyCal.Value == false)
+            if (isHost && DynamicDeadlineMod.incrementalCal.Value == false)
             {
                 float dynamicDifficulty = Mathf.Clamp(Mathf.Ceil( quotaFulfilled / previousDeadline), DynamicDeadlineMod.MinScrapValuePerDay.Value, 1000f);
 
@@ -122,10 +122,10 @@ namespace DynamicDeadlineMod.Patches
                 ES3.Save("previousDeadline", previousDeadline, currentSaveFile);
                 ES3.Save("totalOfAverage", totalOfAverage, currentSaveFile);
             }
-            else if (isHost && DynamicDeadlineMod.legacyCal.Value == true)
+            else if (isHost && DynamicDeadlineMod.incrementalCal.Value == true)
             {
-                __instance.timeUntilDeadline = (float)__instance.totalTime * Mathf.Clamp(Mathf.Ceil( __instance.profitQuota / DynamicDeadlineMod.legacyDailyValue.Value), minimumDays, maximumDays);
-                DynamicDeadlineMod.Instance.mls.LogInfo("This person is the host and using the legacy difficulty calculations. Changing deadline.");
+                __instance.timeUntilDeadline = (float)__instance.totalTime * Mathf.Clamp(Mathf.Ceil( __instance.profitQuota / DynamicDeadlineMod.MinScrapValuePerDay.Value + (runCount * DynamicDeadlineMod.incrementalDailyValue.Value)), minimumDays, maximumDays);
+                DynamicDeadlineMod.Instance.mls.LogInfo("This person is the host and using the incremental difficulty calculations. Changing deadline.");
                 TimeOfDay.Instance.SyncTimeClientRpc(__instance.globalTime, (int)__instance.timeUntilDeadline);
             }
             else


### PR DESCRIPTION
This PR incorporates the concept proposed in #5 . Instead of maintaining the legacy mode alongside it, the new incremental approach now replaces it entirely. Its name has been changed to "Incremental Mode," integrating the suggested idea seamlessly. The default setting remains the dynamic mode, with the alterations specifically affecting the way the legacy mode operated.

Fixes #5